### PR TITLE
Fix the problem with docker-compose up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ FROM node:12.16.1-alpine
 WORKDIR /app
 
 # install and cache app dependencies
-COPY . .
+COPY package*.json ./
 RUN yarn
-RUN yarn add antd
-RUN yarn add react-jinke-music-player
+COPY . .
 
-EXPOSE 3000
 # start app
 CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -2,11 +2,8 @@
 HEDSPIFY - Album Audio
 
 # How to install
-**There is problem with `docker-compose up`**
 *****
-- Build image: `docker-compose build`
-- Search: `docker image -ls` and find IMAGE ID of `react-itss1_react` image
-- Run: `docker run -it [IMAGE ID]`
+- Build and run: `docker-compose up --build`
 
 # How to pull request
 ****

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - .:/app
     ports:
       - '3000:3000'
-    # command: 'yarn start'
+    tty: true


### PR DESCRIPTION
As of version 3.4.1, react-scripts exits after start-up which will cause the container to exit. Thus the need for interactive mode.
Learn more: https://github.com/facebook/create-react-app/issues/8688